### PR TITLE
feat: add Packit integration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,21 @@
+upstream_package_name: insights-ansible-playbook-verifier
+downstream_package_name: insights-ansible-playbook-verifier
+specfile_path: insights-ansible-playbook-verifier.spec
+
+srpm_build_deps:
+  - make
+
+actions:
+  create-archive:
+    - bash -c "make build tarball VERSION=${PACKIT_PROJECT_VERSION}"
+    - bash -c 'echo rpm/insights-ansible-playbook-verifier-*.tar.*'
+  fix-spec-file:
+    # fill in Release as if packit would have done it
+    - bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:\1${PACKIT_RPMSPEC_RELEASE}%{?dist}/\" insights-ansible-playbook-verifier.spec"
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - centos-stream-10
+      - fedora-all


### PR DESCRIPTION
Add a basic configuration for building PRs using Packit, using CentOS Stream 10 and supported Fedora's.

The actions are needed to:
- create the release tarball and tweak the spec file using the existing build system
- override fix-spec-file to only do the Release manipulation that Packit would otherwise do by default