### PR TITLE
fix: Run subshells with LC_ALL=C.UTF-8

### DIFF
--- a/python/insights_ansible_playbook_lib/crypto.py
+++ b/python/insights_ansible_playbook_lib/crypto.py
@@ -94,7 +94,7 @@ class GPGCommand:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,
-            env={"GNUPGHOME": self._home},  # type: ignore
+            env={"GNUPGHOME": self._home, "LC_ALL": "C.UTF-8"},  # type: ignore
         )
         stdout, stderr = version_process.communicate()
         if version_process.returncode != 0:
@@ -149,7 +149,7 @@ class GPGCommand:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,
-            env={"GNUPGHOME": self._home},  # type: ignore
+            env={"GNUPGHOME": self._home, "LC_ALL": "C.UTF-8"},  # type: ignore
         )
         _, stderr = shutdown_process.communicate()
         if shutdown_process.returncode != 0:
@@ -194,6 +194,7 @@ class GPGCommand:
             self._raw_command,  # type: ignore
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env={"LC_ALL": "C.UTF-8"},
         )
         stdout, stderr = process.communicate()
 

--- a/python/tests-integration/test_verifier.py
+++ b/python/tests-integration/test_verifier.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import subprocess
 import sys
@@ -38,6 +39,7 @@ def test_official_playbook(filename: str):
         stderr=subprocess.PIPE,
         universal_newlines=True,
         check=False,
+        env={**os.environ, "LC_ALL": "UTF-8"},
     )
 
     # The playbooks may and may not include newline as EOF.

--- a/python/tests-unit/test_crypto.py
+++ b/python/tests-unit/test_crypto.py
@@ -100,6 +100,7 @@ def _initialize_gpg_environment(home):
         ["/usr/bin/gpg", "--homedir", home, "--import", public_key],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env={"LC_ALL": "UTF-8"},
     )
     process.communicate()
     assert process.returncode == 0
@@ -112,6 +113,7 @@ def _initialize_gpg_environment(home):
         ["/usr/bin/gpg", "--homedir", home, "--import", private_key],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env={"LC_ALL": "UTF-8"},
     )
     process.communicate()
     assert process.returncode == 0
@@ -124,6 +126,7 @@ def _initialize_gpg_environment(home):
         ["/usr/bin/gpg", "--homedir", home, "--detach-sign", "--armor", file],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env={"LC_ALL": "UTF-8"},
     )
     process.communicate()
     assert process.returncode == 0


### PR DESCRIPTION
* Card ID: RHINENG-11802
* Card ID: CCT-653

Ensure we get Unicode data back when we run GPG in a subshell. This will ensure we are able to parse output of the command even if the host is configured to use non-UTF-8 character set.

Originally opened as https://github.com/RedHatInsights/insights-core/pull/4182