### PR TITLE
chore: Update build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Python runtime
 __pycache__/
 *.egg-info/
+# Python builds
+build/
 # Python testing
 .coverage
 htmlcov

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION?=0.0.0
-BUILDROOT?=fedora-40-x86_64
+BUILDROOT?=/etc/mock/default.cfg
 
 .PHONY: build
 build: build-py

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ python3 -m coverage html
 The Python verifier can be built as an RPM package. The following command will build an `.noarch.rpm` in `rpm/` directory.
 
 ```shell
+dnf install -y epel-release  # CentOS Stream, RHEL
+dnf install -y rpmdevtools mock
 make rpm VERSION=1.0.0 BUILDROOT=fedora-40-x86_64
 ```
 


### PR DESCRIPTION
- Use default mock buildroot from the system by default
- Add build prerequisites to README