### PR TITLE
fix: spec: explicitly require gpg

### DIFF
--- a/insights-ansible-playbook-verifier.spec
+++ b/insights-ansible-playbook-verifier.spec
@@ -11,6 +11,7 @@ Source0:  %{name}-%{version}.tar.gz
 BuildArch: noarch
 
 BuildRequires: python3-devel
+Requires: gpg
 %generate_buildrequires
 %pyproject_buildrequires
 


### PR DESCRIPTION
dnf already depends on gpg, so it is installed automatically; that said, add the dependency so it is tracked explicitly.