### PR TITLE
fix: Improve integration test for Verifier

### DIFF
--- a/python/tests-integration/test_verifier.py
+++ b/python/tests-integration/test_verifier.py
@@ -37,9 +37,9 @@ def test_official_playbook(filename: str):
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        universal_newlines=True,
+        text=True,
         check=False,
-        env={**os.environ, "LC_ALL": "UTF-8"},
+        env={**os.environ, "LC_ALL": "C.UTF-8"},
     )
 
     # The playbooks may and may not include newline as EOF.


### PR DESCRIPTION
- The locale there is malformed, ensure it is C.UTF-8
- `universal_newlines` is an old keyword that has been replaced with `text` in Python 3.7. We can use that instead.