### PR TITLE
feat: Create GPG key pair on-demand

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,10 +3,3 @@ useDefault = true
 
 [allowlist]
 description = "Repository-specific configuration"
-
-paths = [
-    # Tests for `crypto.py` contain public and private GPG keypair. They were
-    # generated specifically for this usecase. The owner of the key is:
-    # insights-core (Signing key for unit testing) <insights-core@example.org>
-    "python/tests-unit/test_crypto.py",
-]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,6 @@ make test
 make integration
 ```
 
-Our `gitleaks` configuration explicitly ignores `python/tests-unit/test_crypto.py` that includes dummy private key we use to run tests of the `crypto` module; be extra careful when changing this file.
 
 ## Conventional Commits
 

--- a/python/insights_ansible_playbook_lib/_keygen.py
+++ b/python/insights_ansible_playbook_lib/_keygen.py
@@ -1,0 +1,214 @@
+import argparse
+import logging
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import traceback
+
+import insights_ansible_playbook_lib as lib
+from insights_ansible_playbook_lib.crypto import GPGCommandResult
+
+
+logger = logging.getLogger(__name__)
+
+
+TEMPORARY_GPG_HOME_PARENT_DIRECTORY = "/tmp/"
+TEMPORARY_GPG_HOME_PARENT_DIRECTORY_PREFIX = "insights-ansible-playbook-verifier-gpg-"
+
+
+def _run_gpg_command(command: list[str], fingerprint: bool = False) -> GPGCommandResult:
+    """Run a GPG command in a specific directory.
+
+    :param command: The command to be executed.
+    :param fingerprint: Optional flag to get the fingerprint from the output.
+    """
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={"LC_ALL": "C.UTF-8"},
+        text=fingerprint,
+    )
+    stdout, stderr = process.communicate()
+
+    result = GPGCommandResult(
+        ok=process.returncode == 0,
+        return_code=process.returncode,
+        stdout=stdout.decode("utf-8") if not fingerprint else stdout,
+        stderr=stderr.decode("utf-8") if not fingerprint else stderr,
+        _command=None,
+    )
+
+    if result.ok:
+        logger.debug(f"GPG command {command}: ok.")
+    else:
+        logger.error(f"GPG command {command} returned non-zero code: {result}.")
+
+    return result
+
+
+def _generate_keys() -> str:
+    """
+    Generate GPG keys into a temporary directory.
+    """
+    # Create a temporary directory to store the keys
+    gpg_tmp_dir = tempfile.mkdtemp(
+        dir=TEMPORARY_GPG_HOME_PARENT_DIRECTORY,
+        prefix=TEMPORARY_GPG_HOME_PARENT_DIRECTORY_PREFIX,
+    )
+    logger.debug(f"Generating GPG keys into {gpg_tmp_dir}.")
+
+    instructions_file = pathlib.Path(gpg_tmp_dir) / "keygen"
+    instructions_file.write_text(
+        textwrap.dedent(
+            """
+            Key-Type: EDDSA
+            Key-Curve: ed25519
+            Subkey-Type: ECDH
+            Subkey-Curve: cv25519
+            Name-Real: insights-ansible-playbook-verifier test
+            Expire-Date: 0
+            %no-protection
+            %commit
+            """
+        ).strip()
+    )
+    logger.debug(f"Keys generation instructions written to a file {instructions_file}.")
+
+    # Generate the keys in a temporary directory
+    _run_gpg_command(
+        [
+            "/usr/bin/gpg",
+            "--batch",
+            "--homedir",
+            gpg_tmp_dir,
+            "--generate-key",
+            f"{instructions_file}",
+        ]
+    )
+
+    return gpg_tmp_dir
+
+
+def _export_key_pair(gpg_tmp_dir: str, keys_path: str) -> None:
+    """
+    Export the generated key pair to the `keys_path` directory.
+
+    :param gpg_tmp_dir: The GPG home directory where the key pair was generated.
+    :param keys_path: The directory where the key pair should be exported.
+    """
+    _run_gpg_command(
+        [
+            "/usr/bin/gpg",
+            "--homedir",
+            gpg_tmp_dir,
+            "--export",
+            "--armor",
+            "--yes",
+            "--output",
+            f"{keys_path}/key.public.gpg",
+        ]
+    )
+    logger.debug(f"GPG public key written to a file {keys_path}/key.public.gpg.")
+
+    _run_gpg_command(
+        [
+            "/usr/bin/gpg",
+            "--homedir",
+            gpg_tmp_dir,
+            "--export-secret-keys",
+            "--armor",
+            "--yes",
+            "--output",
+            f"{keys_path}/key.private.gpg",
+        ]
+    )
+    logger.debug(f"GPG private key written to a file {keys_path}/key.private.gpg.")
+
+
+def _get_fingerprint(gpg_tmp_dir: str, keys_path: str) -> str:
+    """
+    Get the fingerprint of the generated key pair and write it to a file in the `keys_path` directory.
+
+    :param gpg_tmp_dir: The GPG home directory where the key pair was generated.
+    :param keys_path: The directory where the key pair is exported.
+    """
+    result = _run_gpg_command(
+        [
+            "/usr/bin/gpg",
+            "--homedir",
+            gpg_tmp_dir,
+            "--fingerprint",
+            "insights-ansible-playbook-verifier test",
+        ],
+        fingerprint=True,
+    )
+
+    # Extract the fingerprint from the output
+    match = re.search(r"^\s+([A-F0-9\s]+)", result.stdout, re.MULTILINE)
+    gpg_fingerprint = match.group(1).strip() if match else ""
+
+    # Write the fingerprint to a file
+    with open(f"{keys_path}/key.fingerprint.txt", "w") as fingerprint_file:
+        fingerprint_file.write(gpg_fingerprint)
+        logger.debug(f"GPG fingerprint written to a file {fingerprint_file.name}")
+
+    return gpg_fingerprint
+
+
+def run() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Display logs",
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        type=pathlib.Path,
+        default=pathlib.Path.cwd(),
+        metavar="DIR",
+        help="Directory to store the key pair (default: current working directory)",
+    )
+    args = parser.parse_args()
+
+    # Generate the keys
+    gpg_tmp_dir = _generate_keys()
+
+    # Export the keys to the specified directory
+    os.makedirs(args.directory, exist_ok=True)
+    _export_key_pair(gpg_tmp_dir, str(args.directory))
+
+    # Get the fingerprint of the generated key pair
+    _get_fingerprint(gpg_tmp_dir, str(args.directory))
+
+    # Clean up the temporary directory
+    shutil.rmtree(gpg_tmp_dir)
+
+
+def main() -> None:
+    debug: bool = "--debug" in sys.argv
+    lib._configure_logging(debug=debug)
+
+    try:
+        run()
+        print(
+            "GPG keys were generated to 'key.public.gpg', 'key.private.gpg', 'key.fingerprint.txt."
+        )
+    except Exception as exc:
+        logger.critical("Unhandled exception occured, aborting.")
+        if debug:
+            traceback.print_exc()
+        else:
+            print(exc)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests-unit/test_crypto.py
+++ b/python/tests-unit/test_crypto.py
@@ -7,77 +7,10 @@ import tempfile
 from unittest import mock
 
 from insights_ansible_playbook_lib import crypto
+from insights_ansible_playbook_lib import _keygen
 
 
-# GPG2 exports keys in a way gpg1.4 cannot read. Since gpg1.4 is present in the
-# Ubuntu image that is used in CI to test Python 2.6, we have to use the old
-# version, so it is recognised by all CI branches.
-#
-# $ gpg --gen-key            # gpg1.x
-# $ gpg --full-generate-key  # gpg2.x
-# $ gpg --list-secret-keys --keyid-format long
-# $ KEYID=xxx (line `sec`, after the `/` character)
-# $ gpg --armor --export $KEYID
-# $ gpg --armor --export-secret-keys $KEYID
-
-GPG_PUBLIC_KEY = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-Version: GnuPG v1
-
-mQENBGUlPEcBCACXhinLd4KiyQ9CWXM+gpgo0HMuTdESTlVVDYRjm/ebazephXq7
-0hhAhXallAQJkaXFPuLETumwFYPx60agUDWsUie8gk3TLE+ejuTxoda0Yo6rehsD
-zds1ptHQLzar00SFUlfiJXnMaobXLeNjDSglkynQC4uQODouDa1jkSRfNbDJOJYd
-IBbPBIaJ3PlNrdVutPcx4yIZM1siqMZ9k0g2iYPWyp0ceuP0jpCTPc5TRRP5pLuz
-INRJzhfJ+oPtbFt8Y4s1xEZ0Kfy0sA8Awk3VJqzoCU3ILBU5cGquQDdNggxTRSPV
-X5Z4nW2zjN9lXAkwr29NL1rA1jjLt+c5upYZABEBAAG0SGluc2lnaHRzLWNvcmUg
-KFNpZ25pbmcga2V5IGZvciB1bml0IHRlc3RpbmcpIDxpbnNpZ2h0cy1jb3JlQGV4
-YW1wbGUub3JnPokBOAQTAQIAIgUCZSU8RwIbAwYLCQgHAwIGFQgCCQoLBBYCAwEC
-HgECF4AACgkQn+6Vu126uXAHdgf/Q8a7Jruhyn+EDLL94gAc6kXubvVArVe9Rdpo
-HwG7cj8wUa/7zd7FUcYJuz6bbebgmmlRwFf1CeodGURFpfwf1dkiKV5QqobeXhRp
-srrkeLlMR8bZVFSCvU+oOETpJfMo6feDI/tQrOcIpxrd/cEu2XSQ1JBM/+8NbQiU
-Ma1cWHOmQJ1OD7jWOllUq5hDs1vtUzPORUsYe1V1Dcx89gdlhfc1cc30yoLzDNqu
-0Abn34CAthUkr0sWplzltXOY+Za1kOmQVlaLQ0W3tq8BDi79bdHpTtD/g9QO++Nc
-r5xdP+tPNWAOUlyi7S6qscDLhMWv7o4eLq6UL9eUC/M2CWJSKg==
-=9pSV
------END PGP PUBLIC KEY BLOCK-----
-"""
-
-GPG_PRIVATE_KEY = """-----BEGIN PGP PRIVATE KEY BLOCK-----
-Version: GnuPG v1
-
-lQOYBGUlPEcBCACXhinLd4KiyQ9CWXM+gpgo0HMuTdESTlVVDYRjm/ebazephXq7
-0hhAhXallAQJkaXFPuLETumwFYPx60agUDWsUie8gk3TLE+ejuTxoda0Yo6rehsD
-zds1ptHQLzar00SFUlfiJXnMaobXLeNjDSglkynQC4uQODouDa1jkSRfNbDJOJYd
-IBbPBIaJ3PlNrdVutPcx4yIZM1siqMZ9k0g2iYPWyp0ceuP0jpCTPc5TRRP5pLuz
-INRJzhfJ+oPtbFt8Y4s1xEZ0Kfy0sA8Awk3VJqzoCU3ILBU5cGquQDdNggxTRSPV
-X5Z4nW2zjN9lXAkwr29NL1rA1jjLt+c5upYZABEBAAEAB/0QIdsaTA+PCEwFGuPv
-sFTF56eTsvpC8i8YnpdNSaI7nFcxR8JQ8+XcHLmMmG0znZuiG/dlwicUNb42CAAd
-ely0i4yqf88MYCfb8EfEyB/FVcbtz9LHfWfM1wV4nkY6VgRyE1nC/I1yq5bOmxae
-CZ0QHxJxEYGa6bmcBJ3Ev4O5VSKZRRByPI0HXmVB6GoqVtmwa7TFrlgLM5GPbgVe
-P76lNY2me8jEnHqzrPpuCB/N0VSCEUf45RV+TNjWL1lpF8JPzXS8oGoxcDoo+sIQ
-AdcfMFrRtf3DW8kJRZC8i4T9++/k3Sjak9GE8ocekCDJkFPRkKv3A4T8nvmMKbNx
-fugZBADAGD+u4Uhwlyzvr84wmwIPcozhQhTWot8dom6LCiZ47sfyG1qVhvxqDKtc
-ttPv+VfA0RyJb9PUKbOf71hA7lMm0qHyX6KTknYYl8u+s/ra8VSwdNyl2/DQDf2j
-OjnIMLM9IC6TMQ/mvpvRmXLc6m6HfL6ZBAbAL0EwOMUAUelnBQQAye626NZJTZ3E
-mQ9z6l6UEi3IZIw+uJfSg/HL4MgU4zRNsOqyJyizdmVzQm0h+1aHQu1SuFsllPXF
-DOKR/IlkjQJCbiU1wZASYYJuwmmVdG4HqZD0bjKU40fJgzBJhOfnhi079jnZzMsL
-+NltcmAtUFKteWsPZe7Blic4QmIbtwUEAIick2Ai788yKGrAry5XBwHNcSIYKNr2
-FFWwjFQWAK82hG2tiKCtF8vg58KBvGR3KNUlCLqDeP85jK7+IuaExSlWKYxIKo70
-8Vfpqpyol/+V1yZ2duEcPSXtrMTg5Yl/7PITyGPnM4mFjvwg+cuYRDqYTT0kWbrl
-WxtODNwtZdIURTm0SGluc2lnaHRzLWNvcmUgKFNpZ25pbmcga2V5IGZvciB1bml0
-IHRlc3RpbmcpIDxpbnNpZ2h0cy1jb3JlQGV4YW1wbGUub3JnPokBOAQTAQIAIgUC
-ZSU8RwIbAwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AACgkQn+6Vu126uXAHdgf/
-Q8a7Jruhyn+EDLL94gAc6kXubvVArVe9RdpoHwG7cj8wUa/7zd7FUcYJuz6bbebg
-mmlRwFf1CeodGURFpfwf1dkiKV5QqobeXhRpsrrkeLlMR8bZVFSCvU+oOETpJfMo
-6feDI/tQrOcIpxrd/cEu2XSQ1JBM/+8NbQiUMa1cWHOmQJ1OD7jWOllUq5hDs1vt
-UzPORUsYe1V1Dcx89gdlhfc1cc30yoLzDNqu0Abn34CAthUkr0sWplzltXOY+Za1
-kOmQVlaLQ0W3tq8BDi79bdHpTtD/g9QO++Ncr5xdP+tPNWAOUlyi7S6qscDLhMWv
-7o4eLq6UL9eUC/M2CWJSKg==
-=ZQ6H
------END PGP PRIVATE KEY BLOCK-----
-"""
-
-GPG_FINGERPRINT = "E884 7216 86A8 1EE3 EBF4  5771 9FEE 95BB 5DBA B970"
-GPG_OWNER = "insights-core (Signing key for unit testing) <insights-core@example.org>"
+GPG_OWNER = "insights-ansible-playbook-verifier test"
 
 
 def _initialize_gpg_environment(home):
@@ -86,37 +19,40 @@ def _initialize_gpg_environment(home):
     The home directory is populated with the following files:
     - key.public.gpg
     - key.private.gpg
+    - key.fingerprint.txt
     - file.txt
     - file.txt.asc
     """
-    # Save the public key into temporary file
-    public_key = home + "/key.public.gpg"
-    with open(public_key, "w") as f:
-        f.write(GPG_PUBLIC_KEY)
+    # Generate the keys and save them
+    gpg_tmp_dir = _keygen._generate_keys()
+    _keygen._export_key_pair(gpg_tmp_dir, home)
+
+    # Import the public key
     # It is strictly not necessary to import both public and private keys,
     #  the private key should be enough.
     #  However, the Python 2.6 CI image requires that.
     process = subprocess.Popen(
-        ["/usr/bin/gpg", "--homedir", home, "--import", public_key],
+        ["/usr/bin/gpg", "--homedir", home, "--import", f"{home}/key.public.gpg"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={"LC_ALL": "UTF-8"},
+        env={"LC_ALL": "C.UTF-8"},
     )
     process.communicate()
     assert process.returncode == 0
 
-    # Save the private key into temporary file and import it
-    private_key = home + "/key.private.gpg"
-    with open(private_key, "w") as f:
-        f.write(GPG_PRIVATE_KEY)
+    # Import the private key
     process = subprocess.Popen(
-        ["/usr/bin/gpg", "--homedir", home, "--import", private_key],
+        ["/usr/bin/gpg", "--homedir", home, "--import", f"{home}/key.private.gpg"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={"LC_ALL": "UTF-8"},
+        env={"LC_ALL": "C.UTF-8"},
     )
     process.communicate()
     assert process.returncode == 0
+
+    # Get the fingerprint of the key
+    gpg_fingerprint = _keygen._get_fingerprint(gpg_tmp_dir, home)
+    assert os.path.exists(home + "/key.fingerprint.txt")
 
     # Create a file and sign it
     file = home + "/file.txt"
@@ -126,13 +62,15 @@ def _initialize_gpg_environment(home):
         ["/usr/bin/gpg", "--homedir", home, "--detach-sign", "--armor", file],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={"LC_ALL": "UTF-8"},
+        env={"LC_ALL": "C.UTF-8"},
     )
     process.communicate()
     assert process.returncode == 0
 
     # Ensure the signature has been created
     assert os.path.exists(home + "/file.txt.asc")
+
+    return gpg_fingerprint
 
 
 @mock.patch(
@@ -142,7 +80,7 @@ def _initialize_gpg_environment(home):
 def test_valid_signature():
     """A detached file signature can be verified."""
     home = tempfile.mkdtemp()
-    _initialize_gpg_environment(home)
+    gpg_fingerprint = _initialize_gpg_environment(home)
 
     # Run the test
     result = crypto.verify_gpg_signed_file(
@@ -156,7 +94,7 @@ def test_valid_signature():
     assert True is result.ok
     assert "" == result.stdout
     assert f'gpg: Good signature from "{GPG_OWNER}"' in result.stderr
-    assert f"Primary key fingerprint: {GPG_FINGERPRINT}" in result.stderr
+    assert f"Primary key fingerprint: {gpg_fingerprint}" in result.stderr
     assert 0 == result.return_code
 
     assert not os.path.isfile(result._command._home)
@@ -169,7 +107,7 @@ def test_valid_signature():
 def test_invalid_signature():
     """A bad detached file signature can be detected."""
     home = tempfile.mkdtemp()
-    _initialize_gpg_environment(home)
+    gpg_fingerprint = _initialize_gpg_environment(home)
 
     # Change the contents of the file, making the signature incorrect
     with open(home + "/file.txt", "w") as f:
@@ -187,7 +125,7 @@ def test_invalid_signature():
     assert not result.ok
     assert "" == result.stdout
     assert f'gpg: BAD signature from "{GPG_OWNER}"' in result.stderr
-    assert f"Primary key fingerprint: {GPG_FINGERPRINT}" not in result.stderr
+    assert f"Primary key fingerprint: {gpg_fingerprint}" not in result.stderr
     assert 1 == result.return_code
 
     assert not os.path.isfile(result._command._home)

--- a/python/tests-unit/test_keygen.py
+++ b/python/tests-unit/test_keygen.py
@@ -1,0 +1,77 @@
+import os.path
+import shutil
+import tempfile
+
+from unittest import mock
+
+from insights_ansible_playbook_lib import _keygen
+
+
+@mock.patch(
+    "insights_ansible_playbook_lib._keygen.TEMPORARY_GPG_HOME_PARENT_DIRECTORY",
+    "/tmp/",
+)
+def test_run_valid_gpg_command():
+    """A valid GPG command can be executed."""
+    home = tempfile.mkdtemp()
+
+    # Run the test
+    result = _keygen._run_gpg_command(
+        ["/usr/bin/gpg", "--batch", "--homedir", home, "--version"],
+    )
+
+    # Verify results
+    assert True is result.ok
+    assert "gpg (GnuPG)" in result.stdout
+    assert f"Home: {home}" in result.stdout
+    assert "" == result.stderr
+    assert 0 == result.return_code
+
+    shutil.rmtree(home)
+
+
+@mock.patch(
+    "insights_ansible_playbook_lib._keygen.TEMPORARY_GPG_HOME_PARENT_DIRECTORY",
+    "/tmp/",
+)
+def test_run_invalid_gpg_command():
+    """An invalid GPG command can be detected."""
+    home = tempfile.mkdtemp()
+
+    # Run the test
+    result = _keygen._run_gpg_command(
+        ["/usr/bin/gpg", "--batch", "--homedir", home, "--invalid-command"],
+    )
+
+    # Verify results
+    assert not result.ok
+    assert "" == result.stdout
+    assert "gpg: invalid option" in result.stderr
+    assert 2 == result.return_code
+
+    shutil.rmtree(home)
+
+
+@mock.patch(
+    "insights_ansible_playbook_lib._keygen.TEMPORARY_GPG_HOME_PARENT_DIRECTORY",
+    "/tmp/",
+)
+def test_generate_gpg_key_pair():
+    """A GPG key pair with a fingerprint can be generated."""
+    home = tempfile.mkdtemp()
+
+    # Run the test
+    gpg_tmp_dir = _keygen._generate_keys()
+    _keygen._export_key_pair(gpg_tmp_dir, home)
+    fingerprint = _keygen._get_fingerprint(gpg_tmp_dir, home)
+
+    # Verify results
+    assert os.path.exists(gpg_tmp_dir)
+    assert os.path.exists(gpg_tmp_dir + "/keygen")
+    assert os.path.exists(home + "/key.public.gpg")
+    assert os.path.exists(home + "/key.private.gpg")
+    assert os.path.exists(home + "/key.fingerprint.txt")
+    assert fingerprint == open(home + "/key.fingerprint.txt").read().strip()
+
+    shutil.rmtree(gpg_tmp_dir)
+    shutil.rmtree(home)


### PR DESCRIPTION
- Card ID: CCT-708

The file `test_crypto.py` contains hardcoded public and private GPG keys used for testing purposes. This PR adds the functionality to generate GPG key pair dynamically for testing, removing the need for hardcoded keys. The code for generating keys can be found in the file `_keygen.py`, so it is also runnable as a module from a terminal.