### PR TITLE
ci: add dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
Enable dependabot for the "main" branch, letting it scan for outdated GitHub Actions used in workflows on a weekly basis.