### PR TITLE
feat: Improve test coverage of crypto.py

### DIFF
--- a/python/insights_ansible_playbook_lib/crypto.py
+++ b/python/insights_ansible_playbook_lib/crypto.py
@@ -223,7 +223,7 @@ class GPGCommand:
         """
         try:
             setup_result = self._setup()
-            if not setup_result:
+            if not setup_result.ok:
                 logger.debug("GPG setup failed.")
                 return setup_result
 


### PR DESCRIPTION
* Card ID: CCT-706

While existing tests catch basic invalid playbook scenarios, this update aims to create more tests that cover specific verification failure points. Adding new unit tests helps "freeze" expected verification behavior, making it easier to detect unintended changes in the future.