### PR TITLE
feat: build & test with Packit also on CentOS Stream 9

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,11 +17,13 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
+      - centos-stream-9
       - centos-stream-10
       - fedora-all
 
   - job: tests
     trigger: pull_request
     targets:
+      - centos-stream-9
       - centos-stream-10
       - fedora-all


### PR DESCRIPTION
Now that the project can be built also with setuptools as available in CentOS Stream 9, then build it with Packit & test it using testing-farm also on that distribution.