### PR TITLE
fix: Serialize properly playbooks with empty maps

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -188,7 +188,7 @@ To hash the playbook, we have to serialize it first.
 
 For historical reasons, the serialization format is dictated by `ruamel.yaml`'s loader type `rt` (round-trip) and Python's string serialization logic for lists, basic data types and `collections.OrderedDict`.
 
-Map has to be serialized into `ordereddict([...])`, where its keys and values serialize into list of key-value tuples (`('key', 'value')`).
+Map has to be serialized into `ordereddict([...])`, where its keys and values serialize into list of key-value tuples (`('key', 'value')`). An empty map is serialized into `ordereddict()`.
 
 Booleans are only serialized into `True`/`False` if they have been declared as `true`/`false`; string `yes` is kept as string value `'yes'` and so on.
 

--- a/python/insights_ansible_playbook_lib/serialization.py
+++ b/python/insights_ansible_playbook_lib/serialization.py
@@ -68,6 +68,8 @@ class Serializer:
 
     @classmethod
     def _dict(cls, source: dict) -> str:
+        if not source:
+            return "ordereddict()"
         result = "ordereddict(["
         result += ", ".join(
             "('{key}', {value})".format(key=k, value=cls._obj(v))

--- a/python/tests-unit/test_serializer.py
+++ b/python/tests-unit/test_serializer.py
@@ -12,6 +12,12 @@ class TestPlaybookSerializer:
         expected = "['a', 'b']"
         assert result == expected
 
+    def test_dict_empty(self):
+        source = {}
+        result = serialization.Serializer._dict(source)
+        expected = "ordereddict()"
+        assert result == expected
+
     def test_dict_empty_value(self):
         source = {"a": None}
         result = serialization.Serializer._dict(source)


### PR DESCRIPTION
* Card ID: CCT-1101

Empty maps in playbooks were not being correctly handled by the serializer. To maintain compatibility across various environments, they are now serialized as `ordereddict()`.

This pull request should also be backported into insights-core.