### PR TITLE
fix: Serialize properly playbooks with empty values

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -192,6 +192,8 @@ Map has to be serialized into `ordereddict([...])`, where its keys and values se
 
 Booleans are only serialized into `True`/`False` if they have been declared as `true`/`false`; string `yes` is kept as string value `'yes'` and so on.
 
+Empty values are serialized into `None`.
+
 Strings are quoted when serialized; the type of quoting depends on which quote characters (single and double) are present in a string:
 - a string with no quote characters: it is quoted with single quotes
 - a string with only single quote characters: it is quoted with double quotes, and the single quote characters are left untouched

--- a/python/insights_ansible_playbook_lib/serialization.py
+++ b/python/insights_ansible_playbook_lib/serialization.py
@@ -64,7 +64,7 @@ class Serializer:
         if isinstance(value, str):
             return cls._str(value)
         logger.debug(f"Value type unknown: {value} {type(value).__name__}")
-        return f"'{value}'"
+        return f"{value}"
 
     @classmethod
     def _dict(cls, source: dict) -> str:

--- a/python/tests-unit/test_serializer.py
+++ b/python/tests-unit/test_serializer.py
@@ -12,6 +12,12 @@ class TestPlaybookSerializer:
         expected = "['a', 'b']"
         assert result == expected
 
+    def test_dict_empty_value(self):
+        source = {"a": None}
+        result = serialization.Serializer._dict(source)
+        expected = "ordereddict([('a', None)])"
+        assert result == expected
+
     def test_dict_single(self):
         source = {"a": "a"}
         result = serialization.Serializer._dict(source)


### PR DESCRIPTION
* Card ID: CCT-1102

Empty values in playbooks were not serialized correctly. This commit resolves the issue by ensuring that empty values are not enclosed in quotes in the serialized output.

This pull request should also be backported into insights-core.