### PR TITLE
fix: Correctly handle empty values for signer

### DIFF
--- a/python/insights_ansible_playbook_lib/serialization.py
+++ b/python/insights_ansible_playbook_lib/serialization.py
@@ -1,5 +1,6 @@
 import logging
 import typing
+import yaml
 
 import yaml.parser
 import yaml.scanner
@@ -26,6 +27,11 @@ class CustomSafeConstructor(yaml.constructor.SafeConstructor):
         if value.lstrip("-+").startswith(("0b", "0o", "0x")):
             return super().construct_yaml_int(node)
         return int(value)
+
+
+class CustomYamlDumper(yaml.Dumper):
+    def represent_none(self: yaml.Dumper, data: None) -> yaml.ScalarNode:
+        return self.represent_scalar("tag:yaml.org,2002:null", "")
 
 
 class Loader(

--- a/python/insights_ansible_playbook_signer/app.py
+++ b/python/insights_ansible_playbook_signer/app.py
@@ -14,6 +14,7 @@ import yaml
 
 import insights_ansible_playbook_lib as lib
 from insights_ansible_playbook_lib import crypto
+from insights_ansible_playbook_lib.serialization import CustomYamlDumper
 from insights_ansible_playbook_verifier.app import get_version_from_package
 
 logger = logging.getLogger(__name__)
@@ -218,6 +219,9 @@ def run() -> None:
         help="Load playbook from stdin (the default)",
     )
     args = parser.parse_args()
+
+    # Configure YAML to handle None values
+    yaml.add_representer(type(None), CustomYamlDumper.represent_none)
 
     # Load playbook to sign
     raw_playbook: str = ""

--- a/python/tests-integration/test_signer.py
+++ b/python/tests-integration/test_signer.py
@@ -93,6 +93,7 @@ def ephemeral_gpg_keys(tmp_path: pathlib.Path) -> None:
         # official production playbooks
         "playbooks/insights_remove.yml",
         # custom playbooks signed by official Red Hat key
+        "playbooks/bugs.yml",
         "playbooks/document-from-hell.yml",
         # unsigned playbooks
         "playbooks-unsigned/sample.yml",

--- a/python/tests-unit/test_serializer.py
+++ b/python/tests-unit/test_serializer.py
@@ -1,4 +1,5 @@
 import pytest
+import yaml
 
 from insights_ansible_playbook_lib import serialization
 
@@ -80,3 +81,17 @@ class TestPlaybookSerializer:
     def test_strings_unicode(self, source, expected):
         result = serialization.Serializer._str(source)
         assert result == expected
+
+
+class TestYamlDumper:
+    def test_represent_none(self):
+        """Test that None is represented as an empty string in YAML."""
+        yaml_dumper: yaml.Dumper = yaml.Dumper
+        yaml_dumper.add_representer(
+            type(None), serialization.CustomYamlDumper.represent_none
+        )
+
+        actual: str = yaml.dump({"key": None}, Dumper=serialization.CustomYamlDumper)
+        expected: str = "key:\n"
+
+        assert actual == expected


### PR DESCRIPTION
* Card ID: CCT-1124

The playbook signer generates incorrect signatures when encountering empty values in playbooks. This fix ensures that empty values remains empty instead of being converted to null.