### PR TITLE
Use python3 for pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.9
+  python: python3
 
 exclude: '^data/playbooks/'
 


### PR DESCRIPTION
Letting the pre-commit hooks invoke python3, instead of python3.9, ensures that the pre-commit hooks can execute on a broader variety of operating systems. This lowers the barrier to development work.

See: RHINENG-22318