### PR TITLE
Drop pointless variable

### DIFF
--- a/python/rhc_playbook_lib/_keygen.py
+++ b/python/rhc_playbook_lib/_keygen.py
@@ -17,7 +17,6 @@ from rhc_playbook_lib.crypto import GPGCommandResult
 logger = logging.getLogger(__name__)
 
 
-TEMPORARY_GPG_HOME_PARENT_DIRECTORY = "/tmp/"
 TEMPORARY_GPG_HOME_PARENT_DIRECTORY_PREFIX = "rhc-playbook-verifier-gpg-"
 
 
@@ -57,10 +56,7 @@ def _generate_keys() -> str:
     Generate GPG keys into a temporary directory.
     """
     # Create a temporary directory to store the keys
-    gpg_tmp_dir = tempfile.mkdtemp(
-        dir=TEMPORARY_GPG_HOME_PARENT_DIRECTORY,
-        prefix=TEMPORARY_GPG_HOME_PARENT_DIRECTORY_PREFIX,
-    )
+    gpg_tmp_dir = tempfile.mkdtemp(prefix=TEMPORARY_GPG_HOME_PARENT_DIRECTORY_PREFIX)
     logger.debug(f"Generating GPG keys into {gpg_tmp_dir}.")
 
     instructions_file = pathlib.Path(gpg_tmp_dir) / "keygen"

--- a/python/tests/unit/test_keygen.py
+++ b/python/tests/unit/test_keygen.py
@@ -2,15 +2,9 @@ import os.path
 import shutil
 import tempfile
 
-from unittest import mock
-
 from rhc_playbook_lib import _keygen
 
 
-@mock.patch(
-    "rhc_playbook_lib._keygen.TEMPORARY_GPG_HOME_PARENT_DIRECTORY",
-    "/tmp/",
-)
 def test_run_valid_gpg_command() -> None:
     """A valid GPG command can be executed."""
     home = tempfile.mkdtemp()
@@ -30,10 +24,6 @@ def test_run_valid_gpg_command() -> None:
     shutil.rmtree(home)
 
 
-@mock.patch(
-    "rhc_playbook_lib._keygen.TEMPORARY_GPG_HOME_PARENT_DIRECTORY",
-    "/tmp/",
-)
 def test_run_invalid_gpg_command() -> None:
     """An invalid GPG command can be detected."""
     home = tempfile.mkdtemp()
@@ -52,10 +42,6 @@ def test_run_invalid_gpg_command() -> None:
     shutil.rmtree(home)
 
 
-@mock.patch(
-    "rhc_playbook_lib._keygen.TEMPORARY_GPG_HOME_PARENT_DIRECTORY",
-    "/tmp/",
-)
 def test_generate_gpg_key_pair() -> None:
     """A GPG key pair with a fingerprint can be generated."""
     home = tempfile.mkdtemp()


### PR DESCRIPTION
`rhc_playbook_lib/keygen.py` contains this line:

```python
rhc_playbook_lib._keygen.TEMPORARY_GPG_HOME_PARENT_DIRECTORY = "/tmp/"
```

`tests/unit/test_keygen.py` uses decorators to override it:

```python
@mock.patch(
    "rhc_playbook_lib._keygen.TEMPORARY_GPG_HOME_PARENT_DIRECTORY",
    "/tmp/",
)
```

This is pointless. Drop the variable.

See RHINENG-22318