### PR TITLE
Drop pointless pre-commit file filter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,9 +22,6 @@ repos:
       - id: mypy
         additional_dependencies:
           - types-PyYAML
-        # The test code is not importable, is not annotated, and is difficult to analyze given the
-        # use of pytest.
-        exclude: '^python/tests-.*'
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.0
     hooks:


### PR DESCRIPTION
When the pre-commit config was created, the `python` directory had this structure:

```console
$ tree python/
python/
...
├── tests-integration
│   ├── __init__.py
│   ├── test_signer.py
│   └── test_verifier.py
└── tests-unit
    ├── __init__.py
    ├── test_crypto.py
    ├── test_keygen.py
    ├── test_lib.py
    ├── test_serializer.py
    └── test_verifier.py
```

Consequently, it was appropriate to avoid running mypy against `python/tests-*`. However, the code has since been restructured and somewhat rewritten, meaning that the filter to do so is both ineffective and unnecessary.

See: RHINENG-22318