### PR TITLE
style: Enable PL code check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: ruff-check
         args:
           - '--target-version=py39'
-          - '--select=F,I'
+          - '--select=F,I,PL'
           - '--fix'
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/python/rhc_playbook_lib/crypto.py
+++ b/python/rhc_playbook_lib/crypto.py
@@ -120,7 +120,8 @@ class GPGCommand:
             return False
 
         version_info = tuple(int(v) for v in version.split("."))
-        if len(version_info) < 3:
+        min_ver = (2, 1, 18)
+        if len(version_info) < len(min_ver):
             logger.debug(
                 "GPG version is not recognized: '{version}'.".format(version=version)
             )
@@ -136,7 +137,7 @@ class GPGCommand:
         # - 8.9:  2.2.20
         # - 9.3:  2.3.3
         # which means this code should return `True` for RHEL 8 and above.
-        return version_info >= (2, 1, 18)
+        return version_info >= min_ver
 
     def _cleanup_socket(self) -> None:
         """Stop GPG socket in its home directory."""

--- a/python/tests/unit/test_crypto.py
+++ b/python/tests/unit/test_crypto.py
@@ -109,7 +109,7 @@ def test_invalid_signature() -> None:
     assert "" == result.stdout
     assert f'gpg: BAD signature from "{GPG_OWNER}"' in result.stderr
     assert f"Primary key fingerprint: {gpg_fingerprint}" not in result.stderr
-    assert 1 == result.return_code
+    assert 0 != result.return_code
 
     assert result._command
     assert result._command._home
@@ -138,7 +138,7 @@ def test_invalid_gpg_setup(
     assert not result.ok
     assert "" == result.stdout
     assert "GPG setup failed" in result.stderr
-    assert 1 == result.return_code
+    assert 0 != result.return_code
 
 
 def test_missing_public_key() -> None:
@@ -164,7 +164,7 @@ def test_missing_public_key() -> None:
         f"gpg: can't open '{home}/key.public.gpg': No such file or directory"
         in result.stderr
     )
-    assert 2 == result.return_code
+    assert 0 != result.return_code
 
 
 def test_invalid_public_key() -> None:
@@ -188,7 +188,7 @@ def test_invalid_public_key() -> None:
     assert not result.ok
     assert "" == result.stdout
     assert "gpg: no valid OpenPGP data found" in result.stderr
-    assert 2 == result.return_code
+    assert 0 != result.return_code
 
 
 def test_missing_signed_file() -> None:

--- a/python/tests/unit/test_serializer.py
+++ b/python/tests/unit/test_serializer.py
@@ -68,8 +68,9 @@ class TestPlaybookSerializer(TestCase):
                 self.assertEqual(result, expected)
 
     def test_strings_unicode(self) -> None:
+        # https://docs.astral.sh/ruff/rules/invalid-character-zero-width-space/
         for desc, source, expected in (
-            ("zero-width space", "zw​space", "'zw\\u200bspace'"),
+            ("zero-width space", "zw​space", "'zw\\u200bspace'"),  # noqa:PLE2515
             ("zero-width non-joiner", "zw‌nonjoiner", "'zw\\u200cnonjoiner'"),
             ("zero-width joiner", "👨🏼‍🚀", "'👨🏼\\u200d🚀'"),
         ):


### PR DESCRIPTION
Address the following rule hits:

* https://docs.astral.sh/ruff/rules/magic-value-comparison/
* https://docs.astral.sh/ruff/rules/invalid-character-zero-width-space/

Change some test cases from `assert 1 == result.return_code` to `assert 0 != result.return_code`. This isn't necessary to satisfy the "magic value comparison" rule, but it seems appropriate, as there is no documented criteria to distinguish between non-zero return codes.

See: https://docs.astral.sh/ruff/rules/#pylint-pl

See: RHINENG-26233