### PR TITLE
build: Fix errors in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,9 @@ version = 1.0.0
 author = CSI Client Tools
 author_email = csi-client-tools-bugs@redhat.com
 classifiers =
-    License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
 license = MIT
-license-files = file: LICENSE
+license_files = LICENSE
 description = Verifier for GPG-signed Ansible playbooks
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Change key `metadata.license-files` to `metadata.license_files`. To my knowledge, the former is not and has never been correct. Note that there is also a `project.license-files` key.

Change value `file: LICENSE` to `LICENSE`, as the value should be a comma-separated list of file names.

Drop a license classifier in in favor of the above, as license classifiers are discouraged.

See: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html

See: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-files

See: RHINENG-26451