### PR TITLE
build: Fix warnings in spec file

### DIFF
--- a/rhc-playbook-verifier.spec
+++ b/rhc-playbook-verifier.spec
@@ -5,7 +5,6 @@ Summary:  Ansible playbook verifier for Red Hat Insights
 License:  MIT
 
 URL:      https://github.com/RedHatInsights/%{name}
-# Source0:  %{url}/archive/refs/tags/v%{version}.tar.gz
 Source0:  %{name}-%{version}.tar.gz
 
 BuildArch: noarch


### PR DESCRIPTION
Fix the following warning:

    warning: Macro expanded in comment on line 8: %{url}/archive/refs/tags/v%{version}.tar.gz

See: RHINENG-26451