### PR TITLE
build: Define version just once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 htmlcov
 # RPM builds
 rpm/
+/rhc-playbook-verifier.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,8 +6,10 @@ srpm_build_deps:
   - make
 
 actions:
+  post-upstream-clone:
+    - bash -c 'make rhc-playbook-verifier.spec'
   create-archive:
-    - bash -c "make build tarball VERSION=${PACKIT_PROJECT_VERSION}"
+    - bash -c 'make build-py tarball'
     - bash -c 'echo rpm/rhc-playbook-verifier-*.tar.*'
   fix-spec-file:
     # fill in Release as if packit would have done it

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
-VERSION?=1.0.0
+PYTHON		?= python3
+VERSION = $(shell $(PYTHON) setup.py --version | tr -d '\n')
+
 BUILDROOT?=/etc/mock/default.cfg
 
-.PHONY: build
-build: build-py
-	sed -i "s|Version:.*|Version:  $(VERSION)|" rhc-playbook-verifier.spec
-	@echo "Built $(VERSION)"
+rhc-playbook-verifier.spec: rhc-playbook-verifier.spec.in
+	[[ -n "$(VERSION)" ]]
+	sed -e 's,[@]VERSION[@],$(VERSION),g' $< > $@
 
 .PHONY: build-py
 build-py:
 	@echo "Building Python package" && \
 	cp data/public.gpg python/rhc_playbook_verifier/data/public.gpg
 	cp data/revoked_playbooks.yml python/rhc_playbook_verifier/data/revoked_playbooks.yml
-	sed -i "s|version = .*|version = $(VERSION)|" setup.cfg
 
 .PHONY: tarball
 tarball:
@@ -30,7 +30,7 @@ srpm:
 		rhc-playbook-verifier.spec
 
 .PHONY: rpm
-rpm: build tarball srpm
+rpm: rhc-playbook-verifier.spec tarball srpm
 	mock \
 		--root $(BUILDROOT) \
 		--rebuild \

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The Python verifier can be built as an RPM package. The following command will b
 ```shell
 dnf install -y epel-release  # CentOS Stream, RHEL
 dnf install -y rpmdevtools mock
-make rpm VERSION=1.0.0 BUILDROOT=fedora-40-x86_64
+make rpm BUILDROOT=fedora-40-x86_64
 ```
 
 ## Contributing

--- a/rhc-playbook-verifier.spec.in
+++ b/rhc-playbook-verifier.spec.in
@@ -1,5 +1,5 @@
 Name:     rhc-playbook-verifier
-Version:  1.0.0
+Version:  @VERSION@
 Release:  0%{dist}
 Summary:  Ansible playbook verifier for Red Hat Insights
 License:  MIT

--- a/tmt/main.fmf
+++ b/tmt/main.fmf
@@ -16,4 +16,5 @@
     - make
     - rpmdevtools
     - mock
+    - python3-setuptools
   test: ./package.sh


### PR DESCRIPTION
Currently, the application version is defined in:

* Makefile
* rhc-playbook-verifier.spec
* setup.cfg
* .packit.yaml

This is confusing. Define the application version just once in `setup.cfg`, and let the makefile use that version to compile `rhc-playbook-verifier.spec`.

Note that `$PACKIT_PROJECT_VERSION` and `$VERSION` evaluate to values like "v1.0.0" and "1.0.0", respectively, which breaks packit package builds.

See: RHINENG-26451