### PR TITLE
build: Rewrite make file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,14 @@
 # Python runtime
 __pycache__/
 *.egg-info/
-# Python builds
-build/
+
 # Python testing
 .coverage
 htmlcov
-# RPM builds
-rpm/
+
+# builds
 /rhc-playbook-verifier.spec
+/dist/*
+/srpm/*
+/rpm/*
+/mock/*

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,8 +9,8 @@ actions:
   post-upstream-clone:
     - bash -c 'make rhc-playbook-verifier.spec'
   create-archive:
-    - bash -c 'make build-py tarball'
-    - bash -c 'echo rpm/rhc-playbook-verifier-*.tar.*'
+    - bash -c 'make dist'
+    - bash -c 'echo dist/*.tar.gz'
   fix-spec-file:
     # fill in Release as if packit would have done it
     - bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:\1${PACKIT_RPMSPEC_RELEASE}%{?dist}/\" rhc-playbook-verifier.spec"

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,45 @@
 PYTHON		?= python3
 VERSION = $(shell $(PYTHON) setup.py --version | tr -d '\n')
+SOURCES := $(shell find . -name '*.py' -o -name 'rhc-playbook-verifier.toml')
 
 BUILDROOT?=/etc/mock/default.cfg
 
+# setuptools < 69.3.0 creates archives with dashes, e.g. rhc-playbook-verifier-1.0.0.tar.gz
+# setuptools >= 69.3.0 creates archives with underscores, e.g. rhc_playbook_verifier-1.0.0.tar.gz
+# See: https://setuptools.pypa.io/en/latest/history.html#v69-3-0
+SDIST_PREFIX := $(shell if [[ $$(echo -e "69.3.0\n$$(rpm -q python3-setuptools --qf='%{VERSION}')" | sort -V | head -n 1) == '69.3.0' ]]; then echo 'rhc_playbook_verifier'; else echo 'rhc-playbook-verifier'; fi)
+
 rhc-playbook-verifier.spec: rhc-playbook-verifier.spec.in
 	[[ -n "$(VERSION)" ]]
-	sed -e 's,[@]VERSION[@],$(VERSION),g' $< > $@
+	[[ -n "$(SDIST_PREFIX)" ]]
+	sed -e 's,[@]VERSION[@],$(VERSION),g' -e 's,[@]SDIST_PREFIX[@],$(SDIST_PREFIX),g' $< > $@
 
-.PHONY: build-py
-build-py:
-	@echo "Building Python package" && \
+dist: $(SOURCES)
 	cp data/public.gpg python/rhc_playbook_verifier/data/public.gpg
 	cp data/revoked_playbooks.yml python/rhc_playbook_verifier/data/revoked_playbooks.yml
+	$(PYTHON) setup.py sdist
+	touch $@  # ensure target is newer than prerequisites
 
-.PHONY: tarball
-tarball:
-	mkdir -p "rpm/"
-	rm -rf rpm/rhc-playbook-verifier-$(VERSION).tar.gz
-	git ls-files -z | xargs -0 tar \
-		--create --gzip \
-		--transform "s|^|/rhc-playbook-verifier-$(VERSION)/|" \
-		--file rpm/rhc-playbook-verifier-$(VERSION).tar.gz
-
-.PHONY: srpm
-srpm:
+# --define values are listed in:
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/RPMMacros/#_macros_set_for_the_rpm_and_srpm_build_process
+srpm: rhc-playbook-verifier.spec dist
 	rpmbuild -bs \
-		--define "_sourcedir `pwd`/rpm" \
-		--define "_srcrpmdir `pwd`/rpm" \
+		--define="_sourcedir $(abspath dist)" \
+		--define="_srcrpmdir $(abspath srpm)" \
 		rhc-playbook-verifier.spec
+	touch $@  # ensure target is newer than prerequisites
 
-.PHONY: rpm
-rpm: rhc-playbook-verifier.spec tarball srpm
+rpm: rhc-playbook-verifier.spec dist
+	rpmbuild -bb \
+		--define="_sourcedir $(abspath dist)" \
+		--define="_rpmdir $(abspath rpm)" \
+		rhc-playbook-verifier.spec
+	touch $@
+
+mock: srpm
 	mock \
-		--root $(BUILDROOT) \
+		--root=$(BUILDROOT) \
 		--rebuild \
-		--resultdir "rpm/" \
-		rpm/rhc-playbook-verifier-*.src.rpm
-
-
-.PHONY: clean
-clean: clean-rpm
-
-.PHONY: clean-rpm
-clean-rpm:
-	rm -f rpm/*
+		--resultdir="$(abspath mock)" \
+		srpm/rhc-playbook-verifier-*.src.rpm
+	touch $@  # ensure target is newer than prerequisites

--- a/README.md
+++ b/README.md
@@ -54,12 +54,18 @@ tmt run --all --verbose report --how=html
 
 ## Building
 
-The Python verifier can be built as an RPM package. The following command will build an `.noarch.rpm` in `rpm/` directory.
+The Python verifier can be built as an RPM package.
 
 ```shell
-dnf install -y epel-release  # CentOS Stream, RHEL
-dnf install -y rpmdevtools mock
-make rpm BUILDROOT=fedora-40-x86_64
+# non-isolated build
+dnf -y install rpmdevtools
+make rpm
+
+# isolated build
+dnf -y install mock
+gpasswd --add "$(whoami)" mock
+newgrp mock  # or, log out and back in
+make mock
 ```
 
 ## Contributing

--- a/rhc-playbook-verifier.spec.in
+++ b/rhc-playbook-verifier.spec.in
@@ -5,7 +5,7 @@ Summary:  Ansible playbook verifier for Red Hat Insights
 License:  MIT
 
 URL:      https://github.com/RedHatInsights/%{name}
-Source0:  %{name}-%{version}.tar.gz
+Source0:  @SDIST_PREFIX@-%{version}.tar.gz
 
 BuildArch: noarch
 
@@ -27,7 +27,7 @@ rhc-playbook-signer package cryptographically signs Ansible
 playbooks to be used by the verifier.
 
 %prep
-%autosetup -p1
+%autosetup -p1 -n @SDIST_PREFIX@-%{version}
 
 %build
 %pyproject_wheel

--- a/tmt/package.sh
+++ b/tmt/package.sh
@@ -3,11 +3,11 @@
 set -euo pipefail
 
 cd ../
-make rpm
+make mock
 
 # COPR may already have installed another version of these packages
 dnf --assumeyes remove rhc-playbook-signer rhc-playbook-verifier
-dnf --assumeyes install rpm/rhc-playbook-verifier-*.noarch.rpm
+dnf --assumeyes install mock/rhc-playbook-verifier-*.noarch.rpm
 
 # The executable is intentionally absent from the default paths.
 /usr/libexec/rhc-playbook-verifier --version


### PR DESCRIPTION
Do the following:

* Rewrite all make targets to be real, not phony. In conjunction with a `SOURCES` variable, make can now decide when a new RPM is needed.
* Use standard python tooling when executing the `dist` target to create a .tar.gz sdist source archive.
* Add a new `mock` make target, which is distinct from the `rpm` make target in how an .rpm file is built.
* Drop the `clean` and `clean-rpm` make targets. To the best of my knowledge, they're unused.

See: RHINENG-26451