### PR TITLE
refactor: Drop Popen, GPGCommand, GPGCommandResult

### DIFF
--- a/python/rhc_playbook_lib/__init__.py
+++ b/python/rhc_playbook_lib/__init__.py
@@ -7,6 +7,7 @@ import logging
 import pathlib
 import sys
 import tempfile
+from subprocess import CalledProcessError
 from typing import Any
 
 import yaml
@@ -161,11 +162,9 @@ def verify_play(play: dict, gpg_key: bytes) -> bytes:
         key_file.write_bytes(gpg_key)
 
         logger.info(f"Cryptographically verifying play '{play_name}'.")
-        result: crypto.GPGCommandResult = crypto.verify_gpg_signed_file(
-            digest_file, signature_file, key_file
-        )
-
-        if not result.ok:
+        try:
+            crypto.verify_gpg_signed_file(digest_file, signature_file, key_file)
+        except CalledProcessError as err:
             logger.error(
                 f"Play content failed to match its digest's signature: {serialized_play!r}."
             )
@@ -174,7 +173,7 @@ def verify_play(play: dict, gpg_key: bytes) -> bytes:
                 serialized_play=serialized_play,
                 digest=digest,
                 signature=signature,
-            )
+            ) from err
 
         return digest
 

--- a/python/rhc_playbook_lib/crypto.py
+++ b/python/rhc_playbook_lib/crypto.py
@@ -1,226 +1,53 @@
-import dataclasses
-import errno
 import logging
-import pathlib
-import shutil
 import subprocess
-import tempfile
-import typing
+from contextlib import contextmanager
+from pathlib import Path
+from subprocess import CompletedProcess
+from tempfile import TemporaryDirectory
+from typing import Generator
 
 from rhc_playbook_lib.constants import TEMPORARY_DIRECTORY_PREFIX
 
 logger = logging.getLogger(__name__)
 
 
-@dataclasses.dataclass(frozen=True)
-class GPGCommandResult:
-    """Output of a GPGCommand.
+@contextmanager
+def temp_gpg_dir(key: Path) -> Generator[Path, None, None]:
+    """Create a temporary directory, import the given GPG key into it, and yield the directory.
 
-    :param ok: Result of an operation.
-    :param return_code: Return code of an operation.
-    :param stdout: Standard output of the command.
-    :param stderr: Standard error of the command.
-    :param _command: An optional reference to the GPGCommand object that created the result.
+    GPG commands can be run against this directory, with the ``--homedir`` flag. On teardown, delete
+    the GPG socket in the directory, then delete the directory.
     """
-
-    ok: bool
-    return_code: int
-    stdout: str
-    stderr: str
-    _command: typing.Optional["GPGCommand"]
-
-    def __str__(self) -> str:
-        return "<{cls} ok={ok} return_code={code} stdout={out} stderr={err}>".format(
-            cls=self.__class__.__name__,
-            ok=self.ok,
-            code=self.return_code,
-            out=self.stdout,
-            err=self.stderr,
+    with TemporaryDirectory(prefix=TEMPORARY_DIRECTORY_PREFIX) as dir:
+        subprocess.run(
+            ["/usr/bin/gpg", "--homedir", dir, "--import", str(key.absolute())],
+            check=True,
+            capture_output=True,
         )
-
-
-class GPGCommand:
-    """GPG command run in a temporary environment.
-
-    :param command: The command to be executed.
-    :param key: Path to the GPG public key to check against.
-    :param _home: Path to the temporary GPG home directory.
-    :param _raw_command: The last invoked command.
-    """
-
-    def __init__(self, command: list[str], key: pathlib.Path):
-        self.command: list[str] = command
-        self.key: pathlib.Path = key
-        self._home: typing.Optional[str] = None
-        self._raw_command: typing.Optional[list[str]] = None
-
-    def __str__(self) -> str:
-        return "<{cls} _home={home} _raw_command={raw}>".format(
-            cls=self.__class__.__name__, home=self._home, raw=self._raw_command
-        )
-
-    def _setup(self) -> GPGCommandResult:
-        """Prepare GPG environment."""
-        self._home = tempfile.mkdtemp(prefix=TEMPORARY_DIRECTORY_PREFIX)
-
-        logger.debug(f"Will use temporary environment in '{self._home}'.")
-        result: GPGCommandResult = self._run(["--import", f"{self.key.absolute()!s}"])
-        if not result.ok:
-            logger.error(f"Failed to import key '{self.key!s}': {result}")
-        return result
-
-    def _supports_cleanup_socket(self) -> bool:
-        """Queries for the version of GPG binary.
-
-        :returns: `True` if the gnupg is known for supporting `--kill all`.
-        """
-        version_process = subprocess.Popen(
-            ["/usr/bin/gpg", "--version"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
-            env={"GNUPGHOME": self._home, "LC_ALL": "C.UTF-8"},  # type: ignore
-        )
-        stdout, stderr = version_process.communicate()
-        if version_process.returncode != 0:
-            stderr = "\n".join(
-                "stderr: {line}".format(line=line)
-                for line in stderr.split("\n")
-                if len(line)
-            )
-            logger.warning(f"Could not query for GPG version:\n{stderr}")
-            return False
-
-        for line in stdout.split("\n"):
-            if line.startswith("gpg (GnuPG) "):
-                version = line.split(" ")[-1]  # type: str
-                break
-        else:
-            stdout = "\n".join(
-                "stdout: {line}".format(line=line)
-                for line in stdout.split("\n")
-                if len(line)
-            )
-            logger.debug(
-                f"Could not query for GPG version: output not recognized:\n{stdout}."
-            )
-            return False
-
-        version_info = tuple(int(v) for v in version.split("."))
-        min_ver = (2, 1, 18)
-        if len(version_info) < len(min_ver):
-            logger.debug(
-                "GPG version is not recognized: '{version}'.".format(version=version)
-            )
-            return False
-
-        # `gpgconf --kill` was added in GnuPG 2.1.0-beta2 and `--kill all` exists since 2.1.18.
-        # - 2.1.0b1: commit 7c03c8cc65e68f1d77a5a5a497025191fe5df5e9 in GPG's repository.
-        # - 2.1.18: https://lists.gnupg.org/pipermail/gnupg-announce/2017q1/000401.html
-        #
-        # RHEL versions come with the following gpg versions:
-        # - 6.10: 2.0.14
-        # - 7.9:  2.0.22
-        # - 8.9:  2.2.20
-        # - 9.3:  2.3.3
-        # which means this code should return `True` for RHEL 8 and above.
-        return version_info >= min_ver
-
-    def _cleanup_socket(self) -> None:
-        """Stop GPG socket in its home directory."""
-        # GPG writes a temporary socket file for the gpg-agent into the home
-        # directory. This is only supported since gnupg 2.1.18 (RHEL 8).
-        shutdown_process = subprocess.Popen(
-            ["/usr/bin/gpgconf", "--kill", "all"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
-            env={"GNUPGHOME": self._home, "LC_ALL": "C.UTF-8"},  # type: ignore
-        )
-        _, stderr = shutdown_process.communicate()
-        if shutdown_process.returncode == 0:
-            logger.debug("Killed GPG agent.")
-        else:
-            stderr = "\n".join(
-                "stderr: {line}".format(line=line)
-                for line in stderr.split("\n")
-                if len(line)
-            )
-            logger.warning(
-                "Could not kill the GPG agent, "
-                f"got return code {shutdown_process.returncode}: \n{stderr}."
-            )
-
-    def _cleanup(self) -> None:
-        """Clean up GPG environment."""
-        if self._supports_cleanup_socket():
-            self._cleanup_socket()
-
-        # Older systems do not support `gpgconf --kill`.
-        # The socket may remove its socket file after `rmtree()` has determined
-        # it should be deleted, but before the actual deletion occurs.
-        # This would cause a FileNotFoundError/OSError.
-        for _ in range(5):
-            try:
-                shutil.rmtree(self._home)  # type: ignore
-                logger.debug("Deleted temporary directory.")
-                break
-            except OSError as exc:
-                if exc.errno == errno.ENOENT:
-                    # The file has already been removed by the `gpg-agent`.
-                    continue
-                raise
-        else:
-            logger.debug(f"Could not clean up temporary GPG directory '{self._home}'.")
-
-    def _run(self, command: list[str]) -> "GPGCommandResult":
-        """Run the actual command.
-
-        :returns: The result of the shell command.
-        """
-        self._raw_command = ["/usr/bin/gpg", "--homedir", self._home] + command  # type: ignore
-        process = subprocess.Popen(
-            self._raw_command,  # type: ignore
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env={"LC_ALL": "C.UTF-8"},
-        )
-        stdout, stderr = process.communicate()
-
-        result = GPGCommandResult(
-            ok=process.returncode == 0,
-            return_code=process.returncode,
-            stdout=stdout.decode("utf-8"),
-            stderr=stderr.decode("utf-8"),
-            _command=self,
-        )
-
-        if result.ok:
-            logger.debug(f"GPG command {command}: ok.")
-        else:
-            logger.debug(f"GPG command {command} returned non-zero code: {result}.")
-
-        return result
-
-    def evaluate(self) -> "GPGCommandResult":
-        """Run the command.
-
-        :returns: The result of the shell command.
-        """
         try:
-            setup_result = self._setup()
-            if not setup_result.ok:
-                logger.debug("GPG setup failed.")
-                return setup_result
-
-            return self._run(self.command)
+            yield Path(dir)
         finally:
-            self._cleanup()
+            # `gpgconf --kill` was added in GnuPG 2.1.0-beta2 and `--kill all` exists since 2.1.18.
+            #
+            # * 2.1.0b1: commit 7c03c8cc65e68f1d77a5a5a497025191fe5df5e9 in GPG's repository.
+            # * 2.1.18: https://lists.gnupg.org/pipermail/gnupg-announce/2017q1/000401.html
+            #
+            # The following RHEL images ship with the following packages:
+            #
+            # * rhel-server-7.9-update-12-x86_64-kvm.qcow2  gnupg2-2.0.22-5.el7_5.x86_64
+            # * rhel-8.6-x86_64-kvm.qcow2                   gnupg2-2.2.20-2.el8.x86_64
+            # * rhel-baseos-9.0-update-4-x86_64-kvm.qcow2   gnupg2-2.3.3-2.el9_0.x86_64
+            #
+            # ...which means this command should work on RHEL 8 and above.
+            subprocess.run(
+                ["/usr/bin/gpgconf", "--kill", "all"],
+                env={"GNUPGHOME": str(dir)},
+                check=True,
+                capture_output=True,
+            )
 
 
-def verify_gpg_signed_file(
-    file: pathlib.Path, signature: pathlib.Path, key: pathlib.Path
-) -> GPGCommandResult:
+def verify_gpg_signed_file(file: Path, signature: Path, key: Path) -> CompletedProcess:
     """
     Verify a file that was signed using GPG.
 
@@ -242,20 +69,16 @@ def verify_gpg_signed_file(
             f"Signature '{signature!s}' of file '{file!s}' not found."
         )
 
-    gpg = GPGCommand(command=["--verify", str(signature), str(file)], key=key)
-
-    logger.debug(f"Starting GPG verification process for '{file}'.")
-    result: GPGCommandResult = gpg.evaluate()
-
-    if result.ok:
-        logger.debug(f"Signature verification of '{file}' passed.")
-    else:
-        logger.error(f"Signature verification of '{file}' failed.")
-
-    return result
+    with temp_gpg_dir(key) as dir:
+        logger.debug(f"Starting GPG verification process for '{file}'.")
+        return subprocess.run(
+            ["/usr/bin/gpg", "--homedir", dir, "--verify", signature, file],
+            check=True,
+            capture_output=True,
+        )
 
 
-def sign_file(file: pathlib.Path, key: pathlib.Path) -> GPGCommandResult:
+def sign_file(file: Path, key: Path) -> CompletedProcess:
     """
     Sign a file using GPG.
 
@@ -272,14 +95,10 @@ def sign_file(file: pathlib.Path, key: pathlib.Path) -> GPGCommandResult:
         logger.debug(f"Cannot sign file '{file}', key does not exist.")
         raise FileNotFoundError(f"Key '{key}' not found")
 
-    gpg = GPGCommand(command=["--detach-sign", "--armor", str(file)], key=key)
-
-    logger.debug(f"Starting GPG signing process for '{file}'.")
-    result: GPGCommandResult = gpg.evaluate()
-
-    if result.ok:
-        logger.debug(f"File '{file}' was signed.")
-    else:
-        logger.error(f"File '{file}' could not be signed.")
-
-    return result
+    with temp_gpg_dir(key) as dir:
+        logger.debug(f"Starting GPG signing process for '{file}'.")
+        return subprocess.run(
+            ["/usr/bin/gpg", "--homedir", dir, "--detach-sign", "--armor", file],
+            check=True,
+            capture_output=True,
+        )

--- a/python/rhc_playbook_signer/app.py
+++ b/python/rhc_playbook_signer/app.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import tempfile
 import traceback
+from subprocess import CalledProcessError
 from typing import Optional
 
 import rhc_playbook_lib as lib
@@ -60,9 +61,10 @@ def sign_play_digest(play_digest: bytes, key: pathlib.Path) -> bytes:
         digest_file = temp_path / "digest"
         digest_file.write_bytes(play_digest)
 
-        result = crypto.sign_file(digest_file, key)
-        if not result.ok:
-            raise RuntimeError(f"Could not sign the digest: {result}")
+        try:
+            crypto.sign_file(digest_file, key)
+        except CalledProcessError as err:
+            raise RuntimeError("Could not sign the digest") from err
         return (temp_path / "digest.asc").read_bytes()
 
 

--- a/python/tests/unit/test_crypto.py
+++ b/python/tests/unit/test_crypto.py
@@ -3,6 +3,7 @@
 import subprocess
 from contextlib import ExitStack
 from pathlib import Path
+from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
@@ -81,14 +82,12 @@ class CryptoTestCase(TestCase):
             signature=self.home / "file.txt.asc",
             key=self.home / "key.public.gpg",
         )
-        self.assertTrue(result.ok)
-        self.assertEqual(result.stdout, "")
-        self.assertIn(f'gpg: Good signature from "{GPG_OWNER}"', result.stderr)
-        self.assertIn(f"Primary key fingerprint: {gpg_fingerprint}", result.stderr)
-        self.assertEqual(result.return_code, 0)
-        assert result._command
-        assert result._command._home
-        self.assertFalse(Path(result._command._home).is_file())
+        self.assertEqual(result.stdout.decode(), "")
+        self.assertIn(f'gpg: Good signature from "{GPG_OWNER}"', result.stderr.decode())
+        self.assertIn(
+            f"Primary key fingerprint: {gpg_fingerprint}", result.stderr.decode()
+        )
+        self.assertEqual(result.returncode, 0)
 
     def test_invalid_signature(self) -> None:
         """A bad detached file signature can be detected."""
@@ -98,53 +97,51 @@ class CryptoTestCase(TestCase):
         with (self.home / "file.txt").open("w") as f:
             f.write("an unsigned message")
 
-        result = crypto.verify_gpg_signed_file(
-            file=self.home / "file.txt",
-            signature=self.home / "file.txt.asc",
-            key=self.home / "key.public.gpg",
-        )
+        with self.assertRaises(CalledProcessError) as cm:
+            crypto.verify_gpg_signed_file(
+                file=self.home / "file.txt",
+                signature=self.home / "file.txt.asc",
+                key=self.home / "key.public.gpg",
+            )
 
         # Verify results
-        self.assertFalse(result.ok)
-        self.assertEqual(result.stdout, "")
-        self.assertIn(f'gpg: BAD signature from "{GPG_OWNER}"', result.stderr)
-        self.assertNotIn(f"Primary key fingerprint: {gpg_fingerprint}", result.stderr)
-        self.assertNotEqual(result.return_code, 0)
-        assert result._command
-        assert result._command._home
-        self.assertFalse(Path(result._command._home).is_file())
+        self.assertEqual("", cm.exception.stdout.decode())
+        self.assertIn(
+            f'gpg: BAD signature from "{GPG_OWNER}"', cm.exception.stderr.decode()
+        )
+        self.assertNotIn(
+            f"Primary key fingerprint: {gpg_fingerprint}", cm.exception.stderr.decode()
+        )
 
     def test_missing_public_key(self) -> None:
         """A missing public key can be detected."""
         _initialize_gpg_environment(self.home)
         (self.home / "key.public.gpg").unlink()  # remove public key
-        result: crypto.GPGCommandResult = crypto.verify_gpg_signed_file(
-            file=self.home / "file.txt",
-            signature=self.home / "file.txt.asc",
-            key=self.home / "key.public.gpg",
-        )
-        self.assertFalse(result.ok)
-        self.assertEqual(result.stdout, "")
+        with self.assertRaises(CalledProcessError) as cm:
+            crypto.verify_gpg_signed_file(
+                file=self.home / "file.txt",
+                signature=self.home / "file.txt.asc",
+                key=self.home / "key.public.gpg",
+            )
+        self.assertEqual("", cm.exception.stdout.decode())
         self.assertIn(
             f"gpg: can't open '{self.home}/key.public.gpg': No such file or directory",
-            result.stderr,
+            cm.exception.stderr.decode(),
         )
-        self.assertNotEqual(result.return_code, 0)
 
     def test_invalid_public_key(self) -> None:
         """An invalid public key can be detected."""
         _initialize_gpg_environment(self.home)
         with (self.home / "key.public.gpg").open("w") as f:
             f.write("invalid key")  # change public key
-        result: crypto.GPGCommandResult = crypto.verify_gpg_signed_file(
-            file=self.home / "file.txt",
-            signature=self.home / "file.txt.asc",
-            key=self.home / "key.public.gpg",
-        )
-        self.assertFalse(result.ok)
-        self.assertEqual(result.stdout, "")
-        self.assertIn("gpg: no valid OpenPGP data found", result.stderr)
-        self.assertNotEqual(result.return_code, 0)
+        with self.assertRaises(CalledProcessError) as cm:
+            crypto.verify_gpg_signed_file(
+                file=self.home / "file.txt",
+                signature=self.home / "file.txt.asc",
+                key=self.home / "key.public.gpg",
+            )
+        self.assertEqual("", cm.exception.stdout.decode())
+        self.assertIn("gpg: no valid OpenPGP data found", cm.exception.stderr.decode())
 
     def test_missing_signed_file(self) -> None:
         """A missing signed file can be detected."""


### PR DESCRIPTION
Python 3.5 added or substantially enhanced the following:

* `subprocess.run()`
* `subprocess.CompletedProcess`
* `subprocess.CalledProcessError`

Together, these provide a comprehensive replacement for:

* `subprocess.Popen`
* `rhc_playbook_lib.crypto.GPGCommand`
* `rhc_playbook_lib.crypto.GPGCommandResult`

Make it so. In addition:

* Rewrite temp dir management logic as a proper context manager.
* Drop unnecessary gpgconf version checks, as rhc-playbook-verifier ships only on RHEL 9 and newer.

See: RHINENG-26836

temp