### PR TITLE
refactor: Revise _keygen.py path handling

### DIFF
--- a/python/rhc_playbook_lib/_keygen.py
+++ b/python/rhc_playbook_lib/_keygen.py
@@ -1,13 +1,12 @@
 import argparse
 import logging
-import os
-import pathlib
 import re
 import subprocess
 import sys
 import textwrap
 import traceback
 from contextlib import contextmanager
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Generator
 
@@ -18,14 +17,15 @@ logger = logging.getLogger(__name__)
 
 
 @contextmanager
-def _generate_keys() -> Generator[str, None, None]:
+def _generate_keys() -> Generator[Path, None, None]:
     """Generate GPG keys into a temporary directory.
 
     Yield the path to the directory into which keys are generated.
     """
-    with TemporaryDirectory(prefix=TEMPORARY_DIRECTORY_PREFIX) as gpg_tmp_dir:
+    with TemporaryDirectory(prefix=TEMPORARY_DIRECTORY_PREFIX) as gpg_tmp_dir_str:
+        gpg_tmp_dir = Path(gpg_tmp_dir_str)
         logger.debug(f"Generating GPG keys into {gpg_tmp_dir}.")
-        instructions_file = pathlib.Path(gpg_tmp_dir) / "keygen"
+        instructions_file = gpg_tmp_dir / "keygen"
         instructions_file.write_text(
             textwrap.dedent(
                 """
@@ -40,9 +40,7 @@ def _generate_keys() -> Generator[str, None, None]:
                 """
             ).strip()
         )
-        logger.debug(
-            f"Keys generation instructions written to a file {instructions_file}."
-        )
+        logger.debug(f"Keys generation instructions written to {instructions_file}.")
         subprocess.run(
             [
                 "/usr/bin/gpg",
@@ -50,14 +48,14 @@ def _generate_keys() -> Generator[str, None, None]:
                 "--homedir",
                 gpg_tmp_dir,
                 "--generate-key",
-                f"{instructions_file}",
+                instructions_file,
             ],
             check=True,
         )
         yield gpg_tmp_dir
 
 
-def _export_key_pair(gpg_tmp_dir: str, keys_path: str) -> None:
+def _export_key_pair(gpg_tmp_dir: Path, keys_path: Path) -> None:
     """
     Export the generated key pair to the `keys_path` directory.
 
@@ -65,8 +63,8 @@ def _export_key_pair(gpg_tmp_dir: str, keys_path: str) -> None:
     :param keys_path: The directory where the key pair should be exported.
     """
     flags_paths = (
-        ("--export", f"{keys_path}/key.public.gpg"),
-        ("--export-secret-keys", f"{keys_path}/key.private.gpg"),
+        ("--export", keys_path / "key.public.gpg"),
+        ("--export-secret-keys", keys_path / "key.private.gpg"),
     )
     for flag, path in flags_paths:
         subprocess.run(
@@ -85,7 +83,7 @@ def _export_key_pair(gpg_tmp_dir: str, keys_path: str) -> None:
         logger.debug(f"GPG key written to {path}")
 
 
-def _get_fingerprint(gpg_tmp_dir: str) -> str:
+def _get_fingerprint(gpg_tmp_dir: Path) -> str:
     """
     Get the fingerprint of the generated key pair.
 
@@ -119,8 +117,8 @@ def run() -> None:
     parser.add_argument(
         "-d",
         "--directory",
-        type=pathlib.Path,
-        default=pathlib.Path.cwd(),
+        type=Path,
+        default=Path.cwd(),
         metavar="DIR",
         help="Directory to store the key pair (default: current working directory)",
     )
@@ -128,11 +126,11 @@ def run() -> None:
 
     # Generate a keypair, export them to args.directory, and get their fingerprint
     with _generate_keys() as gpg_tmp_dir:
-        os.makedirs(args.directory, exist_ok=True)
-        _export_key_pair(gpg_tmp_dir, str(args.directory))
+        args.directory.mkdir(parents=True, exist_ok=True)
+        _export_key_pair(gpg_tmp_dir, args.directory)
         gpg_fingerprint = _get_fingerprint(gpg_tmp_dir)
 
-    with open(f"{args.directory}/key.fingerprint.txt", "w") as fingerprint_file:
+    with (args.directory / "key.fingerprint.txt").open("w") as fingerprint_file:
         fingerprint_file.write(gpg_fingerprint)
         logger.debug(f"GPG fingerprint written to a file {fingerprint_file.name}")
 

--- a/python/tests/unit/test_crypto.py
+++ b/python/tests/unit/test_crypto.py
@@ -26,7 +26,7 @@ def _initialize_gpg_environment(home: Path) -> str:
     """
     # Generate the keys and save them
     with _keygen._generate_keys() as gpg_tmp_dir:
-        _keygen._export_key_pair(gpg_tmp_dir, str(home))
+        _keygen._export_key_pair(gpg_tmp_dir, home)
         gpg_fingerprint = _keygen._get_fingerprint(gpg_tmp_dir)
 
     # Import the public and private keys

--- a/python/tests/unit/test_keygen.py
+++ b/python/tests/unit/test_keygen.py
@@ -27,7 +27,7 @@ class TestCallGPG(TestCase):
     def test_export_key_pair(self) -> None:
         """Call ``_keygen._export_key_pair()``."""
         with _keygen._generate_keys() as gpg_tmp_dir:
-            _keygen._export_key_pair(gpg_tmp_dir, str(self.home))
+            _keygen._export_key_pair(gpg_tmp_dir, self.home)
         self.assertTrue((self.home / "key.public.gpg").is_file())
         self.assertTrue((self.home / "key.private.gpg").is_file())
 

--- a/python/tests/unit/test_lib.py
+++ b/python/tests/unit/test_lib.py
@@ -203,11 +203,9 @@ class TestGetRevocationDigests(TestCase):
         """Test that validation failure raises an exception."""
         with ExitStack() as stack:
             gpg_tmp_dir = stack.enter_context(_keygen._generate_keys())
-            export_dir = stack.enter_context(TemporaryDirectory())
+            export_dir = Path(stack.enter_context(TemporaryDirectory()))
             _keygen._export_key_pair(gpg_tmp_dir, export_dir)
-            handle = stack.enter_context(
-                (Path(export_dir) / "key.public.gpg").open("rb")
-            )
+            handle = stack.enter_context((export_dir / "key.public.gpg").open("rb"))
             invalid_gpg_key = handle.read()
         with self.assertRaisesRegex(
             GPGValidationError, "Play digest does not match its signature"


### PR DESCRIPTION
Broadly, there are two approaches to path handling: with `str`, or with `pathlib.Path`. Revise `_keygen.py` to move from the former to the latter. Consistently using just one type makes for more legible code.

See: RHINENG-26897